### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/barrier_test.ts
+++ b/barrier_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { Barrier } from "./barrier.ts";
 
 Deno.test("Barrier", async (t) => {

--- a/lock_test.ts
+++ b/lock_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { AsyncValue } from "./testutil.ts";
 import { Lock } from "./lock.ts";
 

--- a/mutex.ts
+++ b/mutex.ts
@@ -1,7 +1,7 @@
 import {
   Deferred,
   deferred,
-} from "https://deno.land/std@0.186.0/async/deferred.ts";
+} from "https://deno.land/std@0.211.0/async/deferred.ts";
 
 /**
  * A mutex (mutual exclusion) is a synchronization primitive that grants

--- a/mutex_test.ts
+++ b/mutex_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { AsyncValue } from "./testutil.ts";
 import { Mutex } from "./mutex.ts";
 

--- a/notify.ts
+++ b/notify.ts
@@ -1,7 +1,7 @@
 import {
   Deferred,
   deferred,
-} from "https://deno.land/std@0.186.0/async/deferred.ts";
+} from "https://deno.land/std@0.211.0/async/deferred.ts";
 
 export type WaitOptions = {
   signal?: AbortSignal;
@@ -11,7 +11,7 @@ export type WaitOptions = {
  * Async notifier that allows one or more "waiters" to wait for a notification.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+ * import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
  * import { promiseState } from "./state.ts";
  * import { Notify } from "./notify.ts";
  *

--- a/notify_test.ts
+++ b/notify_test.ts
@@ -1,8 +1,8 @@
-import { delay } from "https://deno.land/std@0.186.0/async/delay.ts";
+import { delay } from "https://deno.land/std@0.211.0/async/delay.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
+} from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { promiseState } from "./state.ts";
 import { Notify } from "./notify.ts";
 

--- a/queue.ts
+++ b/queue.ts
@@ -5,7 +5,7 @@ import { Notify, WaitOptions } from "./notify.ts";
  * popping elements from an empty queue.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+ * import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
  * import { Queue } from "./queue.ts";
  *
  * const queue = new Queue<number>();

--- a/queue_test.ts
+++ b/queue_test.ts
@@ -1,8 +1,8 @@
-import { delay } from "https://deno.land/std@0.186.0/async/delay.ts";
+import { delay } from "https://deno.land/std@0.211.0/async/delay.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
+} from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { promiseState } from "./state.ts";
 import { Queue } from "./queue.ts";
 

--- a/rw_lock_test.ts
+++ b/rw_lock_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { deferred } from "https://deno.land/std@0.186.0/async/deferred.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
+import { deferred } from "https://deno.land/std@0.211.0/async/deferred.ts";
 import { promiseState } from "./state.ts";
 import { AsyncValue } from "./testutil.ts";
 import { RwLock } from "./rw_lock.ts";

--- a/semaphore_test.ts
+++ b/semaphore_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { Semaphore } from "./semaphore.ts";
 
 Deno.test("Semaphore", async (t) => {

--- a/stack.ts
+++ b/stack.ts
@@ -5,7 +5,7 @@ import { Notify, WaitOptions } from "./notify.ts";
  * popping elements from an empty stack.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+ * import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
  * import { Stack } from "./stack.ts";
  *
  * const stack = new Stack<number>();

--- a/stack_test.ts
+++ b/stack_test.ts
@@ -1,8 +1,8 @@
-import { delay } from "https://deno.land/std@0.186.0/async/delay.ts";
+import { delay } from "https://deno.land/std@0.211.0/async/delay.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.186.0/testing/asserts.ts";
+} from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { promiseState } from "./state.ts";
 import { Stack } from "./stack.ts";
 

--- a/state_test.ts
+++ b/state_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
-import { deferred } from "https://deno.land/std@0.186.0/async/deferred.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
+import { deferred } from "https://deno.land/std@0.211.0/async/deferred.ts";
 import { promiseState } from "./state.ts";
 
 Deno.test(

--- a/testutil.ts
+++ b/testutil.ts
@@ -2,7 +2,7 @@
  * A class that wraps a value and allows it to be set asynchronously.
  *
  * ```ts
- * import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+ * import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
  * import { AsyncValue } from "./testutil.ts";
  *
  * const v = new AsyncValue(0);

--- a/testutil_test.ts
+++ b/testutil_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.211.0/testing/asserts.ts";
 import { AsyncValue } from "./testutil.ts";
 
 Deno.test("AsyncValue", async (t) => {


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-async/deno-async/lock.ts

/home/runner/work/deno-async/deno-async/testutil_test.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/queue_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/async/delay.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/stack.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/mutex_test.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/state_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/async/deferred.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/rw_lock_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/async/deferred.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/semaphore_test.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/notify_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/async/delay.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/state.ts

/home/runner/work/deno-async/deno-async/rw_lock.ts

/home/runner/work/deno-async/deno-async/semaphore.ts

/home/runner/work/deno-async/deno-async/mutex.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/async/deferred.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/stack_test.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/async/delay.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/async/delay.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/queue.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/mod.ts

/home/runner/work/deno-async/deno-async/testutil.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/barrier_test.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/lock_test.ts
[1/1] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[1/1] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

/home/runner/work/deno-async/deno-async/barrier.ts

/home/runner/work/deno-async/deno-async/notify.ts
[1/2] Looking for releases: https://deno.land/std@0.186.0/async/deferred.ts
[1/2] Attempting update: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0
[1/2] Update successful: https://deno.land/std@0.186.0/async/deferred.ts -> 0.211.0
[2/2] Looking for releases: https://deno.land/std@0.186.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0
[2/2] Update successful: https://deno.land/std@0.186.0/testing/asserts.ts -> 0.211.0

Successfully updated:
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/delay.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/deferred.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/deferred.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/delay.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/deferred.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/delay.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/async/deferred.ts 0.186.0 -> 0.211.0
https://deno.land/std@0.186.0/testing/asserts.ts 0.186.0 -> 0.211.0

```